### PR TITLE
feat(UI): Make UI calculator-like

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -62,6 +62,7 @@ class Calculator {
         // Generate a clear button to clear calculator's input.
         const clearButton = document.createElement("button");
         clearButton.textContent = "AC";
+        clearButton.id = "AC";
         clearButton.addEventListener("click", this.clear.bind(this));
         operatorContainer.appendChild(clearButton);
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <title>Calculator</title>
     <script src="util.js" defer></script>
     <script src="calculator.js" defer></script>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <main>
@@ -12,6 +13,5 @@
         <div class="operatorContainer"></div>
         <div class="digitContainer"></div>
     </main>
-    
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,38 @@
+body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border: solid;
+    border-radius: 5px;
+    width: 50%;
+    background-color:darkgrey;
+}
+
+.calculatorDisplay {
+    border: solid;
+    min-height: 20px;
+    min-width: 60%;
+    margin-top: 20px;
+    margin-bottom: 10px;
+    background-color: white;
+    text-align: right;
+}
+
+.digitContainer {
+    margin-bottom: 20px;
+}
+
+.operatorContainer button {
+    background-color:darkslateblue;
+    margin-bottom: 5px;
+}
+
+#AC {
+    background-color: yellow;
+}


### PR DESCRIPTION
Make calculator UI much more like a real calculator. Make a border around the main element, which contains the calculator, to give the feel of a hand-held calculator. Make calculator background dark grey, operator buttons dark slate blue, clear button yellow, and input display box white. Provide margins to improve spacing throughout, center content, and round edges of outer border for a less harsh look.